### PR TITLE
feat: Add pages for Golf Course, Cart, and Map management

### DIFF
--- a/src/lib/components/map/MapModal.svelte
+++ b/src/lib/components/map/MapModal.svelte
@@ -1,0 +1,125 @@
+<script lang="ts">
+	import { createEventDispatcher, onMount } from 'svelte';
+	import { X } from 'lucide-svelte';
+
+	export let modalMode: 'create' | 'edit' | 'view';
+	export let selectedMap: any = null;
+
+	const dispatch = createEventDispatcher();
+
+	function getInitialFormData() {
+		return {
+			mapId: '',
+			mapName: '',
+			connectedGolfCourseId: '',
+			version: '1.0',
+			mapData: {
+				resolution: '',
+				size: '',
+				originGps: { latitude: 0, longitude: 0 },
+				rotation: 0
+			},
+			mapFiles: { imageFile: '', metadataFile: '' },
+			courseInfo: { totalCourses: 2, defaultMode: 'auto', defaultSpeedLimit: 15 },
+			mapStatus: { status: 'testing', validationStatus: 'pending', appliedCarts: [], lastUpdate: '' }
+		};
+	}
+
+	let formData = getInitialFormData();
+	$: isReadOnly = modalMode === 'view';
+
+	onMount(() => {
+		if (selectedMap && (modalMode === 'edit' || modalMode === 'view')) {
+			formData = JSON.parse(JSON.stringify(selectedMap));
+		} else {
+			formData.mapId = `MAP-${Date.now().toString().slice(-6)}`;
+		}
+	});
+
+	function handleSave() {
+		if (formData.mapName && formData.connectedGolfCourseId) {
+			dispatch('save', { mode: modalMode, data: formData });
+		} else {
+			alert('맵 이름과 연결 골프장은 필수 항목입니다.');
+		}
+	}
+</script>
+
+<div class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50 p-4">
+	<div class="max-h-[90vh] w-full max-w-3xl overflow-y-auto rounded-lg bg-white dark:bg-gray-800">
+		<div class="flex items-center justify-between border-b p-6 dark:border-gray-700">
+			<h2 class="text-xl font-semibold">
+				{modalMode === 'create' ? '새 맵 등록' : modalMode === 'edit' ? '맵 정보 수정' : '맵 상세 정보'}
+			</h2>
+			<button on:click={() => dispatch('close')} class="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg"><X class="h-5 w-5" /></button>
+		</div>
+
+		<div class="space-y-6 p-6">
+			<!-- 맵 기본 정보 -->
+			<div class="space-y-4 rounded-lg border p-4 dark:border-gray-700">
+				<h3 class="font-semibold">맵 기본 정보</h3>
+				<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+					<div><label for="mapName">맵 이름 *</label><input id="mapName" type="text" bind:value={formData.mapName} disabled={isReadOnly} class="w-full rounded-lg" /></div>
+					<div><label for="version">맵 버전 *</label><input id="version" type="text" bind:value={formData.version} disabled={isReadOnly} class="w-full rounded-lg" /></div>
+				</div>
+				<div><label for="connectedGolfCourseId">연결 골프장 *</label>
+					<select id="connectedGolfCourseId" bind:value={formData.connectedGolfCourseId} disabled={isReadOnly} class="w-full rounded-lg">
+						<option value="">선택하세요</option>
+						<option value="1">서울 컨트리클럽</option>
+						<option value="2">부산 오션뷰 골프장</option>
+					</select>
+				</div>
+			</div>
+
+			<!-- 맵 데이터 정보 -->
+			<div class="space-y-4 rounded-lg border p-4 dark:border-gray-700">
+				<h3 class="font-semibold">맵 데이터 정보</h3>
+				<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+					<div><label for="resolution">해상도 (cm/pixel)</label><input id="resolution" type="text" bind:value={formData.mapData.resolution} disabled={isReadOnly} class="w-full rounded-lg" /></div>
+					<div><label for="size">맵 크기 (m x m)</label><input id="size" type="text" bind:value={formData.mapData.size} disabled={isReadOnly} class="w-full rounded-lg" /></div>
+					<div><label for="lat">맵 원점 위도</label><input id="lat" type="number" bind:value={formData.mapData.originGps.latitude} disabled={isReadOnly} class="w-full rounded-lg" /></div>
+					<div><label for="lon">맵 원점 경도</label><input id="lon" type="number" bind:value={formData.mapData.originGps.longitude} disabled={isReadOnly} class="w-full rounded-lg" /></div>
+				</div>
+			</div>
+
+			<!-- 맵 파일 정보 -->
+			<div class="space-y-4 rounded-lg border p-4 dark:border-gray-700">
+				<h3 class="font-semibold">맵 파일 정보 (TODO: 파일 업로드 기능)</h3>
+				<div><label for="imageFile">맵 이미지 파일 (PNG, JPG)</label><input id="imageFile" type="text" placeholder="파일 경로..." bind:value={formData.mapFiles.imageFile} disabled={isReadOnly} class="w-full rounded-lg" /></div>
+				<div><label for="metadataFile">메타데이터 파일 (JSON)</label><input id="metadataFile" type="text" placeholder="파일 경로..." bind:value={formData.mapFiles.metadataFile} disabled={isReadOnly} class="w-full rounded-lg" /></div>
+			</div>
+
+			<!-- 맵 상태 및 관리 -->
+			<div class="space-y-4 rounded-lg border p-4 dark:border-gray-700">
+				<h3 class="font-semibold">맵 상태 및 관리</h3>
+				<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+					<div><label for="status">맵 상태</label>
+						<select id="status" bind:value={formData.mapStatus.status} disabled={isReadOnly} class="w-full rounded-lg">
+							<option value="active">활성</option>
+							<option value="testing">테스트 중</option>
+							<option value="inactive">비활성</option>
+						</select>
+					</div>
+					<div><label for="validationStatus">검증 상태</label>
+						<select id="validationStatus" bind:value={formData.mapStatus.validationStatus} disabled={isReadOnly} class="w-full rounded-lg">
+							<option value="verified">검증 완료</option>
+							<option value="pending">검증 대기</option>
+							<option value="failed">검증 실패</option>
+						</select>
+					</div>
+				</div>
+			</div>
+		</div>
+
+		<div class="flex items-center justify-end gap-3 border-t px-6 py-4 dark:border-gray-700">
+			{#if !isReadOnly}
+				<button on:click={() => dispatch('close')} class="rounded-lg border bg-white px-4 py-2 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-700">취소</button>
+				<button on:click={handleSave} class="rounded-lg bg-blue-600 px-4 py-2 text-white hover:bg-blue-700">
+					{modalMode === 'create' ? '등록' : '수정'}
+				</button>
+			{:else}
+				<button on:click={() => dispatch('close')} class="rounded-lg bg-gray-600 px-4 py-2 text-white hover:bg-gray-700">닫기</button>
+			{/if}
+		</div>
+	</div>
+</div>

--- a/src/lib/mock/carts.json
+++ b/src/lib/mock/carts.json
@@ -1,0 +1,113 @@
+[
+  {
+    "id": "CART-001",
+    "cartName": "자율주행 1호",
+    "modelYear": "2024",
+    "manufacturer": "DY",
+    "assignedGolfCourseId": "1",
+    "hardware": {
+      "mcu": true,
+      "vcu": true,
+      "vpu": true,
+      "acu": true
+    },
+    "sensors": ["3d-lidar", "stereo-camera", "gps-ins", "lte"],
+    "capabilities": {
+      "supportedModes": ["manual", "auto", "autonomous"],
+      "maxSpeed": 20,
+      "battery": {
+        "type": "Li-ion",
+        "capacity": "10kWh",
+        "expectedHours": 8
+      }
+    },
+    "network": {
+      "macAddress": "00:1A:2B:3C:4D:5E",
+      "ip": "192.168.1.101",
+      "isStatic": true
+    },
+    "mqtt": {
+      "clientId": "CART-001-CLIENT",
+      "qos": 2
+    },
+    "cartStatus": {
+      "currentState": "available",
+      "lastInspection": "2025-01-10",
+      "nextInspection": "2025-07-10"
+    }
+  },
+  {
+    "id": "CART-002",
+    "cartName": "베이직 5호",
+    "modelYear": "2022",
+    "manufacturer": "YAMAHA",
+    "assignedGolfCourseId": "1",
+    "hardware": {
+      "mcu": true,
+      "vcu": true,
+      "vpu": false,
+      "acu": false
+    },
+    "sensors": ["gps-ins", "wifi"],
+    "capabilities": {
+      "supportedModes": ["manual", "auto"],
+      "maxSpeed": 15,
+      "battery": {
+        "type": "Lead-Acid",
+        "capacity": "8kWh",
+        "expectedHours": 6
+      }
+    },
+    "network": {
+      "macAddress": "00:1A:2B:3C:4D:5F",
+      "ip": "192.168.1.102",
+      "isStatic": false
+    },
+    "mqtt": {
+      "clientId": "CART-002-CLIENT",
+      "qos": 1
+    },
+    "cartStatus": {
+      "currentState": "maintenance",
+      "lastInspection": "2025-01-05",
+      "nextInspection": "2025-02-05"
+    }
+  },
+  {
+    "id": "CART-003",
+    "cartName": "고장난 카트",
+    "modelYear": "2023",
+    "manufacturer": "Club Car",
+    "assignedGolfCourseId": "2",
+    "hardware": {
+      "mcu": true,
+      "vcu": true,
+      "vpu": true,
+      "acu": false
+    },
+    "sensors": ["stereo-camera", "gps-ins", "wifi"],
+    "capabilities": {
+      "supportedModes": ["manual", "auto"],
+      "maxSpeed": 18,
+      "battery": {
+        "type": "Li-ion",
+        "capacity": "10kWh",
+        "expectedHours": 7
+      }
+    },
+    "network": {
+      "macAddress": "00:1A:2B:3C:4D:6A",
+      "ip": "",
+      "isStatic": false
+    },
+    "mqtt": {
+      "clientId": "CART-003-CLIENT",
+      "qos": 1
+    },
+    "cartStatus": {
+      "currentState": "broken",
+      "lastInspection": "2024-11-20",
+      "nextInspection": ""
+    }
+  }
+]

--- a/src/lib/mock/golf-courses.json
+++ b/src/lib/mock/golf-courses.json
@@ -1,0 +1,101 @@
+[
+	{
+		"id": "1",
+		"courseName": "서울 컨트리클럽",
+		"courseNameEn": "Seoul Country Club",
+		"courseCode": "SCC001",
+		"address": {
+			"zipcode": "04521",
+			"address1": "서울 중구 세종대로 110",
+			"address2": "본관 10층"
+		},
+		"contact": {
+			"phone": "02-123-4567",
+			"fax": "02-123-4568",
+			"email": "info@seoulcc.co.kr"
+		},
+		"location": {
+			"latitude": 37.5665,
+			"longitude": 126.9780,
+			"altitude": 38.5,
+			"coordinateSystem": "WGS84"
+		},
+		"operation": {
+			"totalHoles": 18,
+			"operatingHours": {
+				"summer": "06:00 - 19:00",
+				"winter": "07:00 - 17:00"
+			},
+			"closedDays": "매주 월요일",
+			"cartPolicy": {
+				"fairwayAccess": true,
+				"rainPolicy": "그린 위 운행 금지",
+				"maxSpeed": 15
+			}
+		},
+		"environment": {
+			"terrain": ["hilly"],
+			"gpsShadedAreas": {
+				"count": 2,
+				"locations": "4번홀 그린, 12번홀 티박스"
+			},
+			"specialNotes": "동절기에는 일부 홀이 폐쇄될 수 있습니다."
+		},
+		"totalCarts": 45,
+		"activeCarts": 32,
+		"status": "active",
+		"lastModified": "2025-01-15T10:30:00Z",
+		"createdAt": "2024-06-15T09:00:00Z"
+	},
+	{
+		"id": "2",
+		"courseName": "부산 오션뷰 골프장",
+		"courseNameEn": "Busan Ocean View Golf",
+		"courseCode": "BOV002",
+		"address": {
+			"zipcode": "48021",
+			"address1": "부산 해운대구 달맞이길 62번길",
+			"address2": ""
+		},
+		"contact": {
+			"phone": "051-742-1234",
+			"email": "contact@busan-ocean.com"
+		},
+		"location": {
+			"latitude": 35.1589,
+			"longitude": 129.1793,
+			"coordinateSystem": "WGS84",
+			"rtk": {
+				"baseLatitude": 35.1590,
+				"baseLongitude": 129.1795,
+				"provider": "KASS"
+			}
+		},
+		"operation": {
+			"totalHoles": 27,
+			"operatingHours": {
+				"summer": "05:30 - 20:00",
+				"winter": "06:30 - 18:00"
+			},
+			"closedDays": "연중무휴",
+			"cartPolicy": {
+				"fairwayAccess": false,
+				"rainPolicy": "운행 중단",
+				"maxSpeed": 12
+			}
+		},
+		"environment": {
+			"terrain": ["hilly", "flat"],
+			"gpsShadedAreas": {
+				"count": 0,
+				"locations": ""
+			},
+			"specialNotes": "바람이 강할 수 있음."
+		},
+		"totalCarts": 60,
+		"activeCarts": 45,
+		"status": "active",
+		"lastModified": "2025-01-14T15:20:00Z",
+		"createdAt": "2024-08-20T11:30:00Z"
+	}
+]

--- a/src/lib/mock/maps.json
+++ b/src/lib/mock/maps.json
@@ -1,0 +1,98 @@
+[
+  {
+    "mapId": "MAP_SCC_V1.0",
+    "mapName": "서울 컨트리클럽 기본 맵",
+    "connectedGolfCourseId": "1",
+    "version": "1.0",
+    "createdAt": "2024-11-01T10:00:00Z",
+    "updatedAt": "2024-11-05T14:30:00Z",
+    "mapData": {
+      "resolution": "5cm/pixel",
+      "size": "2000m x 1500m",
+      "originGps": {
+        "latitude": 37.5665,
+        "longitude": 126.9780
+      },
+      "rotation": 2.5
+    },
+    "mapFiles": {
+      "imageFile": "/maps/scc_v1.png",
+      "metadataFile": "/maps/scc_v1.json"
+    },
+    "courseInfo": {
+      "totalCourses": 2,
+      "defaultMode": "auto",
+      "defaultSpeedLimit": 15
+    },
+    "mapStatus": {
+      "status": "active",
+      "appliedCarts": ["CART-001", "CART-002"],
+      "lastUpdate": "맵 생성",
+      "validationStatus": "verified"
+    }
+  },
+  {
+    "mapId": "MAP_SCC_V1.1_TEST",
+    "mapName": "서울 컨트리클럽 테스트 맵",
+    "connectedGolfCourseId": "1",
+    "version": "1.1",
+    "createdAt": "2025-01-20T09:00:00Z",
+    "updatedAt": "2025-01-20T11:00:00Z",
+    "mapData": {
+      "resolution": "5cm/pixel",
+      "size": "2050m x 1550m",
+      "originGps": {
+        "latitude": 37.5668,
+        "longitude": 126.9782
+      },
+      "rotation": 2.5
+    },
+    "mapFiles": {
+      "imageFile": "/maps/scc_v1.1.png",
+      "metadataFile": "/maps/scc_v1.1.json"
+    },
+    "courseInfo": {
+      "totalCourses": 2,
+      "defaultMode": "autonomous",
+      "defaultSpeedLimit": 18
+    },
+    "mapStatus": {
+      "status": "testing",
+      "appliedCarts": [],
+      "lastUpdate": "코스 경로 수정",
+      "validationStatus": "pending"
+    }
+  },
+  {
+    "mapId": "MAP_BOV_V2.0",
+    "mapName": "부산 오션뷰 신규 맵",
+    "connectedGolfCourseId": "2",
+    "version": "2.0",
+    "createdAt": "2024-12-10T15:00:00Z",
+    "updatedAt": "2024-12-10T15:00:00Z",
+    "mapData": {
+      "resolution": "4cm/pixel",
+      "size": "2500m x 2000m",
+      "originGps": {
+        "latitude": 35.1589,
+        "longitude": 129.1793
+      },
+      "rotation": 10.1
+    },
+    "mapFiles": {
+      "imageFile": "/maps/bov_v2.png",
+      "metadataFile": "/maps/bov_v2.json"
+    },
+    "courseInfo": {
+      "totalCourses": 3,
+      "defaultMode": "auto",
+      "defaultSpeedLimit": 14
+    },
+    "mapStatus": {
+      "status": "inactive",
+      "appliedCarts": [],
+      "lastUpdate": "초기 생성",
+      "validationStatus": "failed"
+    }
+  }
+]

--- a/src/routes/dashboard/carts/+page.svelte
+++ b/src/routes/dashboard/carts/+page.svelte
@@ -1,0 +1,199 @@
+<script lang="ts">
+	import { Plus, Search, Filter, Edit, Trash2, Eye } from 'lucide-svelte';
+	import mockCarts from '$lib/mock/carts.json';
+	import CartModal from '$lib/components/cart/CartModal.svelte';
+	import ConfirmDialog from '$lib/components/ui/ConfirmDialog.svelte';
+
+	// 카트 데이터 타입 정의
+	interface Cart {
+		id: string;
+		cartName: string;
+		modelYear: string;
+		manufacturer: string;
+		assignedGolfCourseId: string;
+		hardware: { mcu: boolean; vcu: boolean; vpu: boolean; acu: boolean };
+		sensors: string[];
+		capabilities: {
+			supportedModes: string[];
+			maxSpeed: number;
+			battery: { type: string; capacity: string; expectedHours: number };
+		};
+		network: { macAddress: string; ip: string; isStatic: boolean };
+		mqtt: { clientId: string; qos: number };
+		cartStatus: {
+			currentState: 'available' | 'maintenance' | 'broken' | 'unavailable';
+			lastInspection: string;
+			nextInspection: string;
+		};
+	}
+
+	let carts: Cart[] = mockCarts;
+
+	// 상태 관리
+	let searchQuery = '';
+	let selectedStatus = 'all';
+	let modalMode: 'create' | 'edit' | 'view' = 'create';
+	let selectedCart: Cart | null = null;
+	let showModal = false;
+	let showDeleteDialog = false;
+	let cartToDelete: Cart | null = null;
+
+	// 필터링된 카트 목록
+	$: filteredCarts = carts.filter((cart) => {
+		const matchesSearch =
+			cart.id.toLowerCase().includes(searchQuery.toLowerCase()) ||
+			cart.cartName.toLowerCase().includes(searchQuery.toLowerCase());
+		const matchesStatus = selectedStatus === 'all' || cart.cartStatus.currentState === selectedStatus;
+		return matchesSearch && matchesStatus;
+	});
+
+	// 상태별 정보
+	function getStatusInfo(status: string) {
+		switch (status) {
+			case 'available':
+				return { color: 'text-green-600 bg-green-100 dark:text-green-400 dark:bg-green-900/50', text: '운행 가능' };
+			case 'maintenance':
+				return { color: 'text-yellow-600 bg-yellow-100 dark:text-yellow-400 dark:bg-yellow-900/50', text: '정비 중' };
+			case 'broken':
+				return { color: 'text-red-600 bg-red-100 dark:text-red-400 dark:bg-red-900/50', text: '고장' };
+			default:
+				return { color: 'text-gray-600 bg-gray-100 dark:text-gray-400 dark:bg-gray-700', text: '미사용' };
+		}
+	}
+
+	// CRUD 액션
+	function handleCreate() {
+		modalMode = 'create';
+		selectedCart = null;
+		showModal = true;
+	}
+	function handleView(cart: Cart) {
+		modalMode = 'view';
+		selectedCart = cart;
+		showModal = true;
+	}
+	function handleEdit(cart: Cart) {
+		modalMode = 'edit';
+		selectedCart = cart;
+		showModal = true;
+	}
+	function handleDelete(cart: Cart) {
+		cartToDelete = cart;
+		showDeleteDialog = true;
+	}
+	function confirmDelete() {
+		if (cartToDelete) {
+			// TODO: API 연동
+			carts = carts.filter((c) => c.id !== cartToDelete?.id);
+		}
+		showDeleteDialog = false;
+	}
+	function handleModalSave(event: CustomEvent) {
+		const { mode, data } = event.detail;
+		if (mode === 'create') {
+			carts = [...carts, data];
+		} else {
+			carts = carts.map((c) => (c.id === data.id ? data : c));
+		}
+		showModal = false;
+	}
+</script>
+
+<svelte:head>
+	<title>카트 관리 - 골프카트 관제 시스템</title>
+</svelte:head>
+
+<div class="space-y-6 p-6">
+	<!-- 헤더 -->
+	<div class="flex items-center justify-between">
+		<div>
+			<h1 class="mb-1 text-2xl font-bold">카트 관리</h1>
+			<p class="text-gray-600">골프장에 등록된 카트의 정보를 관리합니다.</p>
+		</div>
+		<button on:click={handleCreate} class="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-white hover:bg-blue-700">
+			<Plus class="h-4 w-4" />
+			새 카트 등록
+		</button>
+	</div>
+
+	<!-- 검색 및 필터 -->
+	<div class="rounded-lg border bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+		<div class="flex flex-col items-center gap-4 md:flex-row">
+			<div class="relative flex-1">
+				<Search class="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-gray-400" />
+				<input type="text" placeholder="카트 ID, 이름으로 검색..." bind:value={searchQuery} class="w-full rounded-lg border-gray-300 pl-10 dark:border-gray-600 dark:bg-gray-700" />
+			</div>
+			<div class="flex items-center gap-2">
+				<Filter class="h-4 w-4 text-gray-400" />
+				<select bind:value={selectedStatus} class="rounded-lg border-gray-300 dark:border-gray-600 dark:bg-gray-700">
+					<option value="all">전체 상태</option>
+					<option value="available">운행 가능</option>
+					<option value="maintenance">정비 중</option>
+					<option value="broken">고장</option>
+					<option value="unavailable">미사용</option>
+				</select>
+			</div>
+		</div>
+	</div>
+
+	<!-- 카트 목록 테이블 -->
+	<div class="overflow-hidden rounded-lg border bg-white dark:border-gray-700 dark:bg-gray-800">
+		<div class="overflow-x-auto">
+			<table class="w-full">
+				<thead class="bg-gray-50 dark:bg-gray-700">
+					<tr>
+						<th class="px-6 py-3 text-left text-xs font-medium uppercase text-gray-500">카트 ID/이름</th>
+						<th class="px-6 py-3 text-left text-xs font-medium uppercase text-gray-500">할당 골프장</th>
+						<th class="px-6 py-3 text-left text-xs font-medium uppercase text-gray-500">모델/제조사</th>
+						<th class="px-6 py-3 text-left text-xs font-medium uppercase text-gray-500">운행 모드</th>
+						<th class="px-6 py-3 text-left text-xs font-medium uppercase text-gray-500">상태</th>
+						<th class="px-6 py-3 text-right text-xs font-medium uppercase text-gray-500">작업</th>
+					</tr>
+				</thead>
+				<tbody class="divide-y dark:divide-gray-700">
+					{#each filteredCarts as cart (cart.id)}
+						<tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
+							<td class="px-6 py-4">
+								<div class="font-medium">{cart.id}</div>
+								<div class="text-sm text-gray-500">{cart.cartName}</div>
+							</td>
+							<td class="px-6 py-4 text-sm">{cart.assignedGolfCourseId}</td>
+							<td class="px-6 py-4 text-sm">
+								<div>{cart.modelYear}</div>
+								<div class="text-xs text-gray-500">{cart.manufacturer}</div>
+							</td>
+							<td class="px-6 py-4 text-sm">{cart.capabilities.supportedModes.join(', ')}</td>
+							<td class="px-6 py-4">
+								<span class="inline-flex rounded-full px-2 text-xs font-semibold leading-5 {getStatusInfo(cart.cartStatus.currentState).color}">
+									{getStatusInfo(cart.cartStatus.currentState).text}
+								</span>
+							</td>
+							<td class="px-6 py-4 text-right">
+								<div class="flex items-center justify-end gap-2">
+									<button on:click={() => handleView(cart)} title="상세보기" class="p-1.5 text-gray-400 hover:text-blue-600"><Eye class="h-4 w-4" /></button>
+									<button on:click={() => handleEdit(cart)} title="수정" class="p-1.5 text-gray-400 hover:text-green-600"><Edit class="h-4 w-4" /></button>
+									<button on:click={() => handleDelete(cart)} title="삭제" class="p-1.5 text-gray-400 hover:text-red-600"><Trash2 class="h-4 w-4" /></button>
+								</div>
+							</td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
+	</div>
+</div>
+
+<!-- 모달 -->
+{#if showModal}
+	<CartModal {modalMode} {selectedCart} on:save={handleModalSave} on:close={() => (showModal = false)} />
+{/if}
+
+<!-- 삭제 확인 다이얼로그 -->
+{#if showDeleteDialog}
+	<ConfirmDialog
+		title="카트 삭제"
+		message={`'${cartToDelete?.cartName}' 카트를 정말 삭제하시겠습니까?`}
+		on:confirm={confirmDelete}
+		on:cancel={() => (showDeleteDialog = false)}
+	/>
+{/if}

--- a/src/routes/dashboard/golf-courses/+page.svelte
+++ b/src/routes/dashboard/golf-courses/+page.svelte
@@ -1,0 +1,480 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import {
+		Plus,
+		Search,
+		Filter,
+		MapPin,
+		Edit,
+		Trash2,
+		Eye,
+		MoreVertical,
+		Car,
+		Clock,
+		Users,
+		Activity
+	} from 'lucide-svelte';
+	import GolfCourseModal from '@/lib/components/golf/GolfCourseModal.svelte';
+	import ConfirmDialog from '@/lib/components/ui/ConfirmDialog.svelte';
+	import mockGolfCourses from '$lib/mock/golf-courses.json';
+
+	// 골프장 데이터 타입
+	interface GolfCourse {
+		id:string;
+		// 기본 정보
+		courseName: string; // 기존: courseName -> 한글명으로 사용
+		courseNameEn: string;
+		courseCode: string;
+		address: {
+			zipcode: string;
+			address1: string;
+			address2: string;
+		};
+		contact: {
+			phone: string;
+			fax?: string;
+			email: string;
+		};
+
+		// 위치 정보
+		location: {
+			latitude: number;
+			longitude: number;
+			altitude?: number;
+			coordinateSystem: 'WGS84' | 'UTM-K';
+			rtk?: {
+				baseLatitude: number;
+				baseLongitude: number;
+				provider: string;
+			};
+		};
+
+		// 운영 정보
+		operation: {
+			totalHoles: 9 | 18 | 27 | 36;
+			operatingHours: {
+				summer: string;
+				winter: string;
+			};
+			closedDays: string;
+			cartPolicy: {
+				fairwayAccess: boolean;
+				rainPolicy: string;
+				maxSpeed: number; // km/h
+			};
+		};
+
+		// 지형 및 환경 정보
+		environment: {
+			terrain: ('flat' | 'hilly' | 'mountainous')[];
+			gpsShadedAreas: {
+				count: number;
+				locations: string; // 예: "3번홀 티박스, 7번홀 그린 주변"
+			};
+			specialNotes: string;
+		};
+
+		// 기존 필드 유지 (일부는 operation으로 이동)
+		totalCarts: number;
+		activeCarts: number;
+		status: 'active' | 'inactive' | 'maintenance';
+		lastModified: string;
+		createdAt: string;
+	}
+
+	// 임시 데이터 (실제로는 API에서 가져올 데이터)
+	let golfCourses: GolfCourse[] = mockGolfCourses;
+
+	// 상태 관리
+	let searchQuery = '';
+	let selectedStatus = 'all';
+	let sortBy = 'lastModified';
+	let sortOrder: 'asc' | 'desc' = 'desc';
+
+	// 모달 상태
+	let showModal = false;
+	let modalMode: 'create' | 'edit' | 'view' = 'create';
+	let selectedCourse: GolfCourse | null = null;
+
+	// 삭제 확인 다이얼로그
+	let showDeleteDialog = false;
+	let courseToDelete: GolfCourse | null = null;
+
+	// 필터링된 골프장 목록
+	$: filteredCourses = golfCourses
+		.filter((course) => {
+			const matchesSearch =
+				(course.courseName.toLowerCase().includes(searchQuery.toLowerCase()) ||
+					course.courseNameEn.toLowerCase().includes(searchQuery.toLowerCase()) ||
+					course.courseCode.toLowerCase().includes(searchQuery.toLowerCase()) ||
+					course.address.address1.toLowerCase().includes(searchQuery.toLowerCase()));
+
+			const matchesStatus = selectedStatus === 'all' || course.status === selectedStatus;
+
+			return matchesSearch && matchesStatus;
+		})
+		.sort((a, b) => {
+			const aValue = a[sortBy as keyof GolfCourse];
+			const bValue = b[sortBy as keyof GolfCourse];
+
+			if (sortOrder === 'asc') {
+				return aValue < bValue ? -1 : 1;
+			} else {
+				return aValue > bValue ? -1 : 1;
+			}
+		});
+
+	// 상태별 색상 및 텍스트
+	function getStatusInfo(status: string) {
+		switch (status) {
+			case 'active':
+				return {
+					color: 'text-green-600 bg-green-100 dark:text-green-400 dark:bg-green-900/50',
+					text: '운영중'
+				};
+			case 'inactive':
+				return {
+					color: 'text-gray-600 bg-gray-100 dark:text-gray-400 dark:bg-gray-700',
+					text: '비활성'
+				};
+			case 'maintenance':
+				return {
+					color: 'text-yellow-600 bg-yellow-100 dark:text-yellow-400 dark:bg-yellow-900/50',
+					text: '정비중'
+				};
+			default:
+				return { color: 'text-gray-600 bg-gray-100', text: '알 수 없음' };
+		}
+	}
+
+	// 날짜 포맷팅
+	function formatDate(dateString: string) {
+		return new Date(dateString).toLocaleDateString('ko-KR', {
+			year: 'numeric',
+			month: 'short',
+			day: 'numeric',
+			hour: '2-digit',
+			minute: '2-digit'
+		});
+	}
+
+	// CRUD 액션들
+	function handleCreate() {
+		modalMode = 'create';
+		selectedCourse = null;
+		showModal = true;
+	}
+
+	function handleView(course: GolfCourse) {
+		modalMode = 'view';
+		selectedCourse = course;
+		showModal = true;
+	}
+
+	function handleEdit(course: GolfCourse) {
+		modalMode = 'edit';
+		selectedCourse = course;
+		showModal = true;
+	}
+
+	function handleDelete(course: GolfCourse) {
+		courseToDelete = course;
+		showDeleteDialog = true;
+	}
+
+	function confirmDelete() {
+		if (courseToDelete) {
+			// TODO: 서버 API를 호출하여 골프장을 삭제해야 합니다.
+			// 임시로 클라이언트에서만 데이터를 업데이트합니다.
+			golfCourses = golfCourses.filter((c) => c.id !== courseToDelete?.id);
+			console.log('골프장 삭제됨:', courseToDelete.courseName);
+		}
+		showDeleteDialog = false;
+		courseToDelete = null;
+	}
+
+	function handleModalSave(event: CustomEvent) {
+		const { mode, data } = event.detail;
+
+		// TODO: 서버 API를 호출하여 골프장을 생성하거나 수정해야 합니다.
+		// 임시로 클라이언트에서만 데이터를 업데이트합니다.
+		if (mode === 'create') {
+			// 새 골프장 추가
+			const newCourse: GolfCourse = {
+				...data,
+				id: Date.now().toString(),
+				createdAt: new Date().toISOString(),
+				lastModified: new Date().toISOString()
+			};
+			golfCourses = [...golfCourses, newCourse];
+			console.log('새 골프장 추가됨:', newCourse);
+		} else if (mode === 'edit') {
+			// 기존 골프장 수정
+			golfCourses = golfCourses.map((course) =>
+				course.id === data.id ? { ...data, lastModified: new Date().toISOString() } : course
+			);
+			console.log('골프장 수정됨:', data);
+		}
+
+		showModal = false;
+	}
+
+	// 통계 계산
+	$: totalCourses = golfCourses.length;
+	$: activeCourses = golfCourses.filter((c) => c.status === 'active').length;
+	$: totalCartsAll = golfCourses.reduce((sum, c) => sum + c.totalCarts, 0);
+	$: activeCartsAll = golfCourses.reduce((sum, c) => sum + c.activeCarts, 0);
+</script>
+
+<svelte:head>
+	<title>골프장 관리 - 골프카트 관제 시스템</title>
+</svelte:head>
+
+<!-- 골프장 관리 메인 -->
+<div class="space-y-6 p-6">
+	<!-- 헤더 섹션 -->
+	<div class="flex items-center justify-between">
+		<div>
+			<h1 class="mb-1 text-2xl font-bold text-gray-900 dark:text-white">골프장 관리</h1>
+			<p class="text-gray-600 dark:text-gray-400">등록된 골프장의 정보를 관리하고 모니터링합니다</p>
+		</div>
+
+		<!-- 새 골프장 등록 버튼 -->
+		<button
+			on:click={handleCreate}
+			class="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-white transition-colors hover:bg-blue-700"
+		>
+			<Plus class="h-4 w-4" />
+			새 골프장 등록
+		</button>
+	</div>
+
+	<!-- 통계 요약 카드 -->
+	<div class="grid grid-cols-1 gap-6 md:grid-cols-4">
+		<div
+			class="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800"
+		>
+			<div class="flex items-center gap-3">
+				<div class="rounded-lg bg-blue-100 p-2 dark:bg-blue-900/50">
+					<MapPin class="h-5 w-5 text-blue-600 dark:text-blue-400" />
+				</div>
+				<div>
+					<div class="text-xl font-bold text-gray-900 dark:text-white">{totalCourses}</div>
+					<div class="text-sm text-gray-600 dark:text-gray-400">총 골프장</div>
+				</div>
+			</div>
+		</div>
+
+		<div
+			class="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800"
+		>
+			<div class="flex items-center gap-3">
+				<div class="rounded-lg bg-green-100 p-2 dark:bg-green-900/50">
+					<Activity class="h-5 w-5 text-green-600 dark:text-green-400" />
+				</div>
+				<div>
+					<div class="text-xl font-bold text-green-600 dark:text-green-400">{activeCourses}</div>
+					<div class="text-sm text-gray-600 dark:text-gray-400">운영중</div>
+				</div>
+			</div>
+		</div>
+
+		<div
+			class="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800"
+		>
+			<div class="flex items-center gap-3">
+				<div class="rounded-lg bg-purple-100 p-2 dark:bg-purple-900/50">
+					<Car class="h-5 w-5 text-purple-600 dark:text-purple-400" />
+				</div>
+				<div>
+					<div class="text-xl font-bold text-gray-900 dark:text-white">{totalCartsAll}</div>
+					<div class="text-sm text-gray-600 dark:text-gray-400">총 카트</div>
+				</div>
+			</div>
+		</div>
+
+		<div
+			class="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800"
+		>
+			<div class="flex items-center gap-3">
+				<div class="rounded-lg bg-orange-100 p-2 dark:bg-orange-900/50">
+					<Users class="h-5 w-5 text-orange-600 dark:text-orange-400" />
+				</div>
+				<div>
+					<div class="text-xl font-bold text-orange-600 dark:text-orange-400">{activeCartsAll}</div>
+					<div class="text-sm text-gray-600 dark:text-gray-400">운행중 카트</div>
+				</div>
+			</div>
+		</div>
+	</div>
+
+	<!-- 검색 및 필터 -->
+	<div class="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+		<div class="flex flex-col items-center gap-4 md:flex-row">
+			<!-- 검색 -->
+			<div class="relative flex-1">
+				<Search class="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 transform text-gray-400" />
+				<input
+					type="text"
+					placeholder="골프장명, 코드, 지역으로 검색..."
+					bind:value={searchQuery}
+					class="w-full rounded-lg border border-gray-300 bg-white py-2 pr-4 pl-10 text-gray-900 focus:border-transparent focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+				/>
+			</div>
+
+			<!-- 상태 필터 -->
+			<div class="flex items-center gap-2">
+				<Filter class="h-4 w-4 text-gray-400" />
+				<select
+					bind:value={selectedStatus}
+					class="rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-900 focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+				>
+					<option value="all">전체 상태</option>
+					<option value="active">운영중</option>
+					<option value="inactive">비활성</option>
+					<option value="maintenance">정비중</option>
+				</select>
+			</div>
+
+			<!-- 정렬 -->
+			<div class="flex items-center gap-2">
+				<select
+					bind:value={sortBy}
+					class="rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-900 focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+				>
+					<option value="lastModified">최근 수정순</option>
+					<option value="courseName">이름순</option>
+					<option value="createdAt">등록순</option>
+					<option value="totalCarts">카트 수순</option>
+				</select>
+
+				<button
+					on:click={() => (sortOrder = sortOrder === 'asc' ? 'desc' : 'asc')}
+					class="rounded-lg border border-gray-300 p-2 hover:bg-gray-50 dark:border-gray-600 dark:hover:bg-gray-700"
+				>
+					{sortOrder === 'asc' ? '↑' : '↓'}
+				</button>
+			</div>
+		</div>
+	</div>
+
+	<!-- 골프장 목록 테이블 -->
+	<div
+		class="overflow-hidden rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800"
+	>
+		<div class="overflow-x-auto">
+			<table class="w-full">
+				<thead class="bg-gray-50 dark:bg-gray-700">
+					<tr>
+						<th class="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">골프장 정보</th>
+						<th class="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">주소</th>
+						<th class="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">운영 정보</th>
+						<th class="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">상태</th>
+						<th class="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">최근 수정</th>
+						<th class="px-6 py-3 text-right text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">작업</th>
+					</tr>
+				</thead>
+				<tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+					{#each filteredCourses as course (course.id)}
+						<tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
+							<!-- 골프장 정보 -->
+							<td class="px-6 py-4">
+								<div>
+									<div class="text-sm font-medium text-gray-900 dark:text-white">{course.courseName}</div>
+									<div class="text-sm text-gray-500 dark:text-gray-400">{course.courseCode}</div>
+								</div>
+							</td>
+
+							<!-- 주소 -->
+							<td class="px-6 py-4">
+								<div class="text-sm text-gray-900 dark:text-white">{course.address.address1}</div>
+								<div class="text-sm text-gray-500 dark:text-gray-400">{course.address.zipcode}</div>
+							</td>
+
+							<!-- 운영 정보 -->
+							<td class="px-6 py-4">
+								<div class="text-sm text-gray-900 dark:text-white">{course.operation.totalHoles}홀</div>
+								<div class="text-sm text-gray-500 dark:text-gray-400">카트 {course.activeCarts}/{course.totalCarts}</div>
+							</td>
+
+							<!-- 상태 -->
+							<td class="px-6 py-4">
+								<span class="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium {getStatusInfo(course.status).color}">
+									{getStatusInfo(course.status).text}
+								</span>
+							</td>
+
+							<!-- 최근 수정 -->
+							<td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-400">
+								{formatDate(course.lastModified)}
+							</td>
+
+							<!-- 작업 버튼들 -->
+							<td class="px-6 py-4 text-right">
+								<div class="flex items-center justify-end gap-2">
+									<button on:click={() => handleView(course)} title="상세보기" class="p-1.5 text-gray-400 hover:text-blue-600 dark:hover:text-blue-400">
+										<Eye class="h-4 w-4" />
+									</button>
+									<button on:click={() => handleEdit(course)} title="수정" class="p-1.5 text-gray-400 hover:text-green-600 dark:hover:text-green-400">
+										<Edit class="h-4 w-4" />
+									</button>
+									<button on:click={() => handleDelete(course)} title="삭제" class="p-1.5 text-gray-400 hover:text-red-600 dark:hover:text-red-400">
+										<Trash2 class="h-4 w-4" />
+									</button>
+								</div>
+							</td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+
+			<!-- 데이터가 없을 때 -->
+			{#if filteredCourses.length === 0}
+				<div class="py-12 text-center">
+					<MapPin class="mx-auto mb-4 h-12 w-12 text-gray-400" />
+					<h3 class="mb-2 text-lg font-medium text-gray-900 dark:text-white">골프장이 없습니다</h3>
+					<p class="mb-4 text-gray-500 dark:text-gray-400">
+						{searchQuery || selectedStatus !== 'all'
+							? '검색 조건에 맞는 골프장이 없습니다.'
+							: '첫 번째 골프장을 등록해보세요.'}
+					</p>
+					{#if !searchQuery && selectedStatus === 'all'}
+						<button
+							on:click={handleCreate}
+							class="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-white transition-colors hover:bg-blue-700"
+						>
+							<Plus class="h-4 w-4" />
+							골프장 등록
+						</button>
+					{/if}
+				</div>
+			{/if}
+		</div>
+	</div>
+</div>
+
+<!-- 골프장 등록/수정 모달 -->
+{#if showModal}
+	<GolfCourseModal
+		{modalMode}
+		{selectedCourse}
+		on:save={handleModalSave}
+		on:close={() => (showModal = false)}
+	/>
+{/if}
+
+<!-- 삭제 확인 다이얼로그 -->
+{#if showDeleteDialog && courseToDelete}
+	<ConfirmDialog
+		title="골프장 삭제"
+		message="'{courseToDelete.courseName}' 골프장을 정말 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+		confirmText="삭제"
+		cancelText="취소"
+		danger={true}
+		on:confirm={confirmDelete}
+		on:cancel={() => {
+			showDeleteDialog = false;
+			courseToDelete = null;
+		}}
+	/>
+{/if}

--- a/src/routes/dashboard/maps/+page.svelte
+++ b/src/routes/dashboard/maps/+page.svelte
@@ -1,530 +1,188 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
-	import {
-		Plus,
-		Search,
-		Filter,
-		MapPin,
-		Edit,
-		Trash2,
-		Eye,
-		MoreVertical,
-		Car,
-		Clock,
-		Users,
-		Activity
-	} from 'lucide-svelte';
-	import GolfCourseModal from '@/lib/components/golf/GolfCourseModal.svelte';
-	import ConfirmDialog from '@/lib/components/ui/ConfirmDialog.svelte';
+	import { Plus, Search, Filter, Edit, Trash2, Eye, Map, CheckCircle, XCircle, Clock } from 'lucide-svelte';
+	import mockMaps from '$lib/mock/maps.json';
+	import ConfirmDialog from '$lib/components/ui/ConfirmDialog.svelte';
+	import MapModal from '$lib/components/map/MapModal.svelte';
 
-	// 골프장 데이터 타입
-	interface GolfCourse {
-		id: string;
-		courseName: string;
-		courseCode: string;
-		address: {
-			region: string;
-			city: string;
-			country: string;
-		};
-		totalHoles: number;
-		totalCarts: number;
-		activeCarts: number;
-		status: 'active' | 'inactive' | 'maintenance';
-		lastModified: string;
+	interface MapData {
+		mapId: string;
+		mapName: string;
+		connectedGolfCourseId: string;
+		version: string;
 		createdAt: string;
+		updatedAt: string;
+		mapStatus: {
+			status: 'active' | 'testing' | 'inactive';
+			validationStatus: 'verified' | 'pending' | 'failed';
+		};
 	}
 
-	// 임시 데이터 (실제로는 API에서 가져올 데이터)
-	let golfCourses: GolfCourse[] = [
-		{
-			id: '1',
-			courseName: '서울 컨트리클럽',
-			courseCode: 'SCC001',
-			address: { region: '서울', city: '강남구', country: 'KR' },
-			totalHoles: 18,
-			totalCarts: 45,
-			activeCarts: 32,
-			status: 'active',
-			lastModified: '2025-01-15T10:30:00Z',
-			createdAt: '2024-06-15T09:00:00Z'
-		},
-		{
-			id: '2',
-			courseName: '부산 오션뷰 골프장',
-			courseCode: 'BOV002',
-			address: { region: '부산', city: '해운대구', country: 'KR' },
-			totalHoles: 27,
-			totalCarts: 60,
-			activeCarts: 45,
-			status: 'active',
-			lastModified: '2025-01-14T15:20:00Z',
-			createdAt: '2024-08-20T11:30:00Z'
-		},
-		{
-			id: '3',
-			courseName: '제주 파라다이스 골프클럽',
-			courseCode: 'JPG003',
-			address: { region: '제주', city: '서귀포시', country: 'KR' },
-			totalHoles: 36,
-			totalCarts: 80,
-			activeCarts: 65,
-			status: 'active',
-			lastModified: '2025-01-13T08:45:00Z',
-			createdAt: '2024-05-10T14:00:00Z'
-		},
-		{
-			id: '4',
-			courseName: '경기 밸리 골프장',
-			courseCode: 'KVG004',
-			address: { region: '경기', city: '용인시', country: 'KR' },
-			totalHoles: 18,
-			totalCarts: 35,
-			activeCarts: 12,
-			status: 'maintenance',
-			lastModified: '2025-01-12T16:15:00Z',
-			createdAt: '2024-09-05T10:20:00Z'
-		}
-	];
-
-	// 상태 관리
+	let maps: MapData[] = mockMaps;
 	let searchQuery = '';
 	let selectedStatus = 'all';
-	let sortBy = 'lastModified';
-	let sortOrder: 'asc' | 'desc' = 'desc';
 
-	// 모달 상태
 	let showModal = false;
 	let modalMode: 'create' | 'edit' | 'view' = 'create';
-	let selectedCourse: GolfCourse | null = null;
-
-	// 삭제 확인 다이얼로그
+	let selectedMap: MapData | null = null;
 	let showDeleteDialog = false;
-	let courseToDelete: GolfCourse | null = null;
+	let mapToDelete: MapData | null = null;
 
-	// 필터링된 골프장 목록
-	$: filteredCourses = golfCourses
-		.filter((course) => {
-			const matchesSearch =
-				course.courseName.toLowerCase().includes(searchQuery.toLowerCase()) ||
-				course.courseCode.toLowerCase().includes(searchQuery.toLowerCase()) ||
-				course.address.city.toLowerCase().includes(searchQuery.toLowerCase());
+	$: filteredMaps = maps.filter(map => {
+		const matchesSearch =
+			map.mapName.toLowerCase().includes(searchQuery.toLowerCase()) ||
+			map.mapId.toLowerCase().includes(searchQuery.toLowerCase());
+		const matchesStatus = selectedStatus === 'all' || map.mapStatus.status === selectedStatus;
+		return matchesSearch && matchesStatus;
+	});
 
-			const matchesStatus = selectedStatus === 'all' || course.status === selectedStatus;
-
-			return matchesSearch && matchesStatus;
-		})
-		.sort((a, b) => {
-			const aValue = a[sortBy as keyof GolfCourse];
-			const bValue = b[sortBy as keyof GolfCourse];
-
-			if (sortOrder === 'asc') {
-				return aValue < bValue ? -1 : 1;
-			} else {
-				return aValue > bValue ? -1 : 1;
-			}
-		});
-
-	// 상태별 색상 및 텍스트
-	function getStatusInfo(status: string) {
+	function getStatusInfo(status: 'active' | 'testing' | 'inactive') {
 		switch (status) {
-			case 'active':
-				return {
-					color: 'text-green-600 bg-green-100 dark:text-green-400 dark:bg-green-900/50',
-					text: '운영중'
-				};
-			case 'inactive':
-				return {
-					color: 'text-gray-600 bg-gray-100 dark:text-gray-400 dark:bg-gray-700',
-					text: '비활성'
-				};
-			case 'maintenance':
-				return {
-					color: 'text-yellow-600 bg-yellow-100 dark:text-yellow-400 dark:bg-yellow-900/50',
-					text: '정비중'
-				};
-			default:
-				return { color: 'text-gray-600 bg-gray-100', text: '알 수 없음' };
+			case 'active': return { color: 'text-green-600 bg-green-100', text: '활성' };
+			case 'testing': return { color: 'text-blue-600 bg-blue-100', text: '테스트 중' };
+			case 'inactive': return { color: 'text-gray-600 bg-gray-100', text: '비활성' };
 		}
 	}
 
-	// 날짜 포맷팅
-	function formatDate(dateString: string) {
-		return new Date(dateString).toLocaleDateString('ko-KR', {
-			year: 'numeric',
-			month: 'short',
-			day: 'numeric',
-			hour: '2-digit',
-			minute: '2-digit'
-		});
+	function getValidationIcon(status: 'verified' | 'pending' | 'failed') {
+		switch (status) {
+			case 'verified': return CheckCircle;
+			case 'pending': return Clock;
+			case 'failed': return XCircle;
+		}
 	}
 
-	// CRUD 액션들
 	function handleCreate() {
 		modalMode = 'create';
-		selectedCourse = null;
+		selectedMap = null;
 		showModal = true;
 	}
-
-	function handleView(course: GolfCourse) {
+	function handleView(map: MapData) {
 		modalMode = 'view';
-		selectedCourse = course;
+		selectedMap = map;
 		showModal = true;
 	}
-
-	function handleEdit(course: GolfCourse) {
+	function handleEdit(map: MapData) {
 		modalMode = 'edit';
-		selectedCourse = course;
+		selectedMap = map;
 		showModal = true;
 	}
-
-	function handleDelete(course: GolfCourse) {
-		courseToDelete = course;
+	function handleDelete(map: MapData) {
+		mapToDelete = map;
 		showDeleteDialog = true;
 	}
-
 	function confirmDelete() {
-		if (courseToDelete) {
-			golfCourses = golfCourses.filter((c) => c.id !== courseToDelete?.id);
-			console.log('골프장 삭제됨:', courseToDelete.courseName);
+		if (mapToDelete) {
+			maps = maps.filter(m => m.mapId !== mapToDelete?.mapId);
 		}
 		showDeleteDialog = false;
-		courseToDelete = null;
 	}
-
 	function handleModalSave(event: CustomEvent) {
 		const { mode, data } = event.detail;
-
 		if (mode === 'create') {
-			// 새 골프장 추가
-			const newCourse: GolfCourse = {
-				...data,
-				id: Date.now().toString(),
-				createdAt: new Date().toISOString(),
-				lastModified: new Date().toISOString()
-			};
-			golfCourses = [...golfCourses, newCourse];
-			console.log('새 골프장 추가됨:', newCourse);
-		} else if (mode === 'edit') {
-			// 기존 골프장 수정
-			golfCourses = golfCourses.map((course) =>
-				course.id === data.id ? { ...data, lastModified: new Date().toISOString() } : course
-			);
-			console.log('골프장 수정됨:', data);
+			maps = [...maps, data];
+		} else {
+			maps = maps.map((m) => (m.mapId === data.mapId ? data : m));
 		}
-
 		showModal = false;
 	}
 
-	// 통계 계산
-	$: totalCourses = golfCourses.length;
-	$: activeCourses = golfCourses.filter((c) => c.status === 'active').length;
-	$: totalCartsAll = golfCourses.reduce((sum, c) => sum + c.totalCarts, 0);
-	$: activeCartsAll = golfCourses.reduce((sum, c) => sum + c.activeCarts, 0);
 </script>
 
 <svelte:head>
-	<title>골프장 관리 - 골프카트 관제 시스템</title>
+	<title>맵 관리 - 골프카트 관제 시스템</title>
 </svelte:head>
 
-<!-- 골프장 관리 메인 -->
 <div class="space-y-6 p-6">
-	<!-- 헤더 섹션 -->
+	<!-- 헤더 -->
 	<div class="flex items-center justify-between">
 		<div>
-			<h1 class="mb-1 text-2xl font-bold text-gray-900 dark:text-white">골프장 관리</h1>
-			<p class="text-gray-600 dark:text-gray-400">등록된 골프장의 정보를 관리하고 모니터링합니다</p>
+			<h1 class="mb-1 text-2xl font-bold">맵 관리</h1>
+			<p class="text-gray-600">골프장 맵 데이터를 관리하고 버전을 제어합니다.</p>
 		</div>
-
-		<!-- 새 골프장 등록 버튼 -->
-		<button
-			on:click={handleCreate}
-			class="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-white transition-colors hover:bg-blue-700"
-		>
+		<button on:click={handleCreate} class="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-white hover:bg-blue-700">
 			<Plus class="h-4 w-4" />
-			새 골프장 등록
+			새 맵 등록
 		</button>
 	</div>
 
-	<!-- 통계 요약 카드 -->
-	<div class="grid grid-cols-1 gap-6 md:grid-cols-4">
-		<div
-			class="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800"
-		>
-			<div class="flex items-center gap-3">
-				<div class="rounded-lg bg-blue-100 p-2 dark:bg-blue-900/50">
-					<MapPin class="h-5 w-5 text-blue-600 dark:text-blue-400" />
-				</div>
-				<div>
-					<div class="text-xl font-bold text-gray-900 dark:text-white">{totalCourses}</div>
-					<div class="text-sm text-gray-600 dark:text-gray-400">총 골프장</div>
-				</div>
-			</div>
-		</div>
-
-		<div
-			class="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800"
-		>
-			<div class="flex items-center gap-3">
-				<div class="rounded-lg bg-green-100 p-2 dark:bg-green-900/50">
-					<Activity class="h-5 w-5 text-green-600 dark:text-green-400" />
-				</div>
-				<div>
-					<div class="text-xl font-bold text-green-600 dark:text-green-400">{activeCourses}</div>
-					<div class="text-sm text-gray-600 dark:text-gray-400">운영중</div>
-				</div>
-			</div>
-		</div>
-
-		<div
-			class="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800"
-		>
-			<div class="flex items-center gap-3">
-				<div class="rounded-lg bg-purple-100 p-2 dark:bg-purple-900/50">
-					<Car class="h-5 w-5 text-purple-600 dark:text-purple-400" />
-				</div>
-				<div>
-					<div class="text-xl font-bold text-gray-900 dark:text-white">{totalCartsAll}</div>
-					<div class="text-sm text-gray-600 dark:text-gray-400">총 카트</div>
-				</div>
-			</div>
-		</div>
-
-		<div
-			class="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800"
-		>
-			<div class="flex items-center gap-3">
-				<div class="rounded-lg bg-orange-100 p-2 dark:bg-orange-900/50">
-					<Users class="h-5 w-5 text-orange-600 dark:text-orange-400" />
-				</div>
-				<div>
-					<div class="text-xl font-bold text-orange-600 dark:text-orange-400">{activeCartsAll}</div>
-					<div class="text-sm text-gray-600 dark:text-gray-400">운행중 카트</div>
-				</div>
-			</div>
-		</div>
-	</div>
-
 	<!-- 검색 및 필터 -->
-	<div class="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+	<div class="rounded-lg border bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
 		<div class="flex flex-col items-center gap-4 md:flex-row">
-			<!-- 검색 -->
 			<div class="relative flex-1">
-				<Search class="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 transform text-gray-400" />
-				<input
-					type="text"
-					placeholder="골프장명, 코드, 지역으로 검색..."
-					bind:value={searchQuery}
-					class="w-full rounded-lg border border-gray-300 bg-white py-2 pr-4 pl-10 text-gray-900 focus:border-transparent focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-				/>
+				<Search class="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-gray-400" />
+				<input type="text" placeholder="맵 이름, ID로 검색..." bind:value={searchQuery} class="w-full rounded-lg border-gray-300 pl-10 dark:border-gray-600 dark:bg-gray-700" />
 			</div>
-
-			<!-- 상태 필터 -->
 			<div class="flex items-center gap-2">
 				<Filter class="h-4 w-4 text-gray-400" />
-				<select
-					bind:value={selectedStatus}
-					class="rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-900 focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-				>
+				<select bind:value={selectedStatus} class="rounded-lg border-gray-300 dark:border-gray-600 dark:bg-gray-700">
 					<option value="all">전체 상태</option>
-					<option value="active">운영중</option>
+					<option value="active">활성</option>
+					<option value="testing">테스트 중</option>
 					<option value="inactive">비활성</option>
-					<option value="maintenance">정비중</option>
 				</select>
-			</div>
-
-			<!-- 정렬 -->
-			<div class="flex items-center gap-2">
-				<select
-					bind:value={sortBy}
-					class="rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-900 focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-				>
-					<option value="lastModified">최근 수정순</option>
-					<option value="courseName">이름순</option>
-					<option value="createdAt">등록순</option>
-					<option value="totalCarts">카트 수순</option>
-				</select>
-
-				<button
-					on:click={() => (sortOrder = sortOrder === 'asc' ? 'desc' : 'asc')}
-					class="rounded-lg border border-gray-300 p-2 hover:bg-gray-50 dark:border-gray-600 dark:hover:bg-gray-700"
-				>
-					{sortOrder === 'asc' ? '↑' : '↓'}
-				</button>
 			</div>
 		</div>
 	</div>
 
-	<!-- 골프장 목록 테이블 -->
-	<div
-		class="overflow-hidden rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800"
-	>
-		<div class="overflow-x-auto">
-			<table class="w-full">
-				<thead class="bg-gray-50 dark:bg-gray-700">
-					<tr>
-						<th
-							class="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400"
-						>
-							골프장 정보
-						</th>
-						<th
-							class="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400"
-						>
-							위치
-						</th>
-						<th
-							class="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400"
-						>
-							홀/카트
-						</th>
-						<th
-							class="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400"
-						>
-							상태
-						</th>
-						<th
-							class="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400"
-						>
-							최근 수정
-						</th>
-						<th
-							class="px-6 py-3 text-right text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400"
-						>
-							작업
-						</th>
-					</tr>
-				</thead>
-				<tbody class="divide-y divide-gray-200 dark:divide-gray-700">
-					{#each filteredCourses as course (course.id)}
-						<tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
-							<!-- 골프장 정보 -->
-							<td class="px-6 py-4">
-								<div>
-									<div class="text-sm font-medium text-gray-900 dark:text-white">
-										{course.courseName}
-									</div>
-									<div class="text-sm text-gray-500 dark:text-gray-400">
-										{course.courseCode}
-									</div>
-								</div>
-							</td>
-
-							<!-- 위치 -->
-							<td class="px-6 py-4">
-								<div class="text-sm text-gray-900 dark:text-white">
-									{course.address.region}
-									{course.address.city}
-								</div>
-								<div class="text-sm text-gray-500 dark:text-gray-400">
-									{course.address.country}
-								</div>
-							</td>
-
-							<!-- 홀/카트 정보 -->
-							<td class="px-6 py-4">
-								<div class="text-sm text-gray-900 dark:text-white">
-									{course.totalHoles}홀
-								</div>
-								<div class="text-sm text-gray-500 dark:text-gray-400">
-									카트 {course.activeCarts}/{course.totalCarts}
-								</div>
-							</td>
-
-							<!-- 상태 -->
-							<td class="px-6 py-4">
-								<span
-									class="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium {getStatusInfo(
-										course.status
-									).color}"
-								>
-									{getStatusInfo(course.status).text}
-								</span>
-							</td>
-
-							<!-- 최근 수정 -->
-							<td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-400">
-								{formatDate(course.lastModified)}
-							</td>
-
-							<!-- 작업 버튼들 -->
-							<td class="px-6 py-4 text-right">
-								<div class="flex items-center justify-end gap-2">
-									<button
-										on:click={() => handleView(course)}
-										title="상세보기"
-										class="p-1.5 text-gray-400 hover:text-blue-600 dark:hover:text-blue-400"
-									>
-										<Eye class="h-4 w-4" />
-									</button>
-									<button
-										on:click={() => handleEdit(course)}
-										title="수정"
-										class="p-1.5 text-gray-400 hover:text-green-600 dark:hover:text-green-400"
-									>
-										<Edit class="h-4 w-4" />
-									</button>
-									<button
-										on:click={() => handleDelete(course)}
-										title="삭제"
-										class="p-1.5 text-gray-400 hover:text-red-600 dark:hover:text-red-400"
-									>
-										<Trash2 class="h-4 w-4" />
-									</button>
-								</div>
-							</td>
-						</tr>
-					{/each}
-				</tbody>
-			</table>
-
-			<!-- 데이터가 없을 때 -->
-			{#if filteredCourses.length === 0}
-				<div class="py-12 text-center">
-					<MapPin class="mx-auto mb-4 h-12 w-12 text-gray-400" />
-					<h3 class="mb-2 text-lg font-medium text-gray-900 dark:text-white">골프장이 없습니다</h3>
-					<p class="mb-4 text-gray-500 dark:text-gray-400">
-						{searchQuery || selectedStatus !== 'all'
-							? '검색 조건에 맞는 골프장이 없습니다.'
-							: '첫 번째 골프장을 등록해보세요.'}
-					</p>
-					{#if !searchQuery && selectedStatus === 'all'}
-						<button
-							on:click={handleCreate}
-							class="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-white transition-colors hover:bg-blue-700"
-						>
-							<Plus class="h-4 w-4" />
-							골프장 등록
-						</button>
-					{/if}
-				</div>
-			{/if}
-		</div>
+	<!-- 맵 목록 테이블 -->
+	<div class="overflow-hidden rounded-lg border bg-white dark:border-gray-700 dark:bg-gray-800">
+		<table class="w-full">
+			<thead class="bg-gray-50 dark:bg-gray-700">
+				<tr>
+					<th class="px-6 py-3 text-left text-xs font-medium uppercase text-gray-500">맵 이름/ID</th>
+					<th class="px-6 py-3 text-left text-xs font-medium uppercase text-gray-500">버전</th>
+					<th class="px-6 py-3 text-left text-xs font-medium uppercase text-gray-500">연결 골프장</th>
+					<th class="px-6 py-3 text-left text-xs font-medium uppercase text-gray-500">상태</th>
+					<th class="px-6 py-3 text-left text-xs font-medium uppercase text-gray-500">검증</th>
+					<th class="px-6 py-3 text-left text-xs font-medium uppercase text-gray-500">최근 수정일</th>
+					<th class="px-6 py-3 text-right text-xs font-medium uppercase text-gray-500">작업</th>
+				</tr>
+			</thead>
+			<tbody class="divide-y dark:divide-gray-700">
+				{#each filteredMaps as map (map.mapId)}
+				<tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
+					<td class="px-6 py-4">
+						<div class="font-medium">{map.mapName}</div>
+						<div class="text-sm text-gray-500">{map.mapId}</div>
+					</td>
+					<td class="px-6 py-4 text-sm font-mono">v{map.version}</td>
+					<td class="px-6 py-4 text-sm">{map.connectedGolfCourseId}</td>
+					<td class="px-6 py-4">
+						<span class="inline-flex rounded-full px-2 text-xs font-semibold leading-5 {getStatusInfo(map.mapStatus.status).color}">
+							{getStatusInfo(map.mapStatus.status).text}
+						</span>
+					</td>
+					<td class="px-6 py-4">
+						<svelte:component this={getValidationIcon(map.mapStatus.validationStatus)} class="h-5 w-5"
+							class:text-green-500={map.mapStatus.validationStatus === 'verified'}
+							class:text-yellow-500={map.mapStatus.validationStatus === 'pending'}
+							class:text-red-500={map.mapStatus.validationStatus === 'failed'}
+						/>
+					</td>
+					<td class="px-6 py-4 text-sm text-gray-500">{new Date(map.updatedAt).toLocaleDateString()}</td>
+					<td class="px-6 py-4 text-right">
+						<div class="flex items-center justify-end gap-2">
+							<button on:click={() => handleView(map)} title="상세보기" class="p-1.5 text-gray-400 hover:text-blue-600"><Eye class="h-4 w-4" /></button>
+							<button on:click={() => handleEdit(map)} title="수정" class="p-1.5 text-gray-400 hover:text-green-600"><Edit class="h-4 w-4" /></button>
+							<button on:click={() => handleDelete(map)} title="삭제" class="p-1.5 text-gray-400 hover:text-red-600"><Trash2 class="h-4 w-4" /></button>
+						</div>
+					</td>
+				</tr>
+				{/each}
+			</tbody>
+		</table>
 	</div>
 </div>
 
-<!-- 골프장 등록/수정 모달 -->
 {#if showModal}
-	<GolfCourseModal
-		{modalMode}
-		{selectedCourse}
-		on:save={handleModalSave}
-		on:close={() => (showModal = false)}
-	/>
+	<MapModal {modalMode} {selectedMap} on:save={handleModalSave} on:close={() => (showModal = false)} />
 {/if}
 
-<!-- 삭제 확인 다이얼로그 -->
-{#if showDeleteDialog && courseToDelete}
+{#if showDeleteDialog}
 	<ConfirmDialog
-		title="골프장 삭제"
-		message="'{courseToDelete.courseName}' 골프장을 정말 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
-		confirmText="삭제"
-		cancelText="취소"
-		danger={true}
+		title="맵 삭제"
+		message={`'${mapToDelete?.mapName}' (v${mapToDelete?.version}) 맵을 정말 삭제하시겠습니까?`}
 		on:confirm={confirmDelete}
-		on:cancel={() => {
-			showDeleteDialog = false;
-			courseToDelete = null;
-		}}
+		on:cancel={() => (showDeleteDialog = false)}
 	/>
 {/if}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
 					browser: {
 						enabled: true,
 						provider: 'playwright',
-						instances: [{ browser: 'chromium' }]
+						instances: [{ browser: 'chromium', headless: true }]
 					},
 					include: ['src/**/*.svelte.{test,spec}.{js,ts}'],
 					exclude: ['src/lib/server/**'],


### PR DESCRIPTION
This commit introduces a comprehensive set of features for managing core entities in the application.

- **Golf Course Management:** Refactors and enhances the golf course management page, moving it to a dedicated `/dashboard/golf-courses` route. The creation/edit modal has been significantly expanded to include all fields from the specification.

- **Cart Management:** Adds a new page at `/dashboard/carts` for managing carts, complete with a list view, search, filtering, and a detailed creation/edit modal.

- **Map Management:** Adds a new page at `/dashboard/maps` for managing maps, including versioning and status tracking, with a corresponding creation/edit modal.

All pages are built using mock data from JSON files to facilitate frontend development. The test environment has also been configured to run Playwright tests in a headless environment.